### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.3
 
 before_install:
-  - composer self-update
   - composer install
   - composer require php-coveralls/php-coveralls
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "source": "https://github.com/natanfelles/array_simple"
   },
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0"

--- a/tests/ArraySimpleTest.php
+++ b/tests/ArraySimpleTest.php
@@ -112,11 +112,11 @@ class ArraySimpleTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertEquals('bbcb', \array_simple_value('b[b][c][b]', $this->array));
 
-		$this->assertEquals(null, \array_simple_value('a[x]', $this->array));
+		$this->assertNull(\array_simple_value('a[x]', $this->array));
 
-		$this->assertEquals(null, \array_simple_value('c', $this->array));
+		$this->assertNull(\array_simple_value('c', $this->array));
 
-		$this->assertEquals(null, \array_simple_value('z', []));
+		$this->assertNull(\array_simple_value('z', []));
 	}
 
 	public function testArraySimple()


### PR DESCRIPTION
# Changed log
- Using the `assertNull` to assert whether the actual value is null.
- Apply fixes PSR-2 coding style with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
- The PHP package should require `>=7.1` at least so that it can support the `PHPUnit 7+` version.
- Move the `php-coveralls` to the `require-dev` block in `composer.json`.
- Remove `composer self-update` in Travis CI build because this command will be executed automatically during Travis build.